### PR TITLE
fix issue #3 列表项添加点击跳转到其他页面之后回来, 下拉菜单就不会弹出了

### DIFF
--- a/lib/drapdown_common.dart
+++ b/lib/drapdown_common.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/widgets.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 
 enum DropdownEvent {
   // the menu will hide
@@ -158,14 +158,16 @@ abstract class DropdownState<T extends DropdownWidget> extends State<T> {
 
   @override
   void didChangeDependencies() {
-    if (widget.controller == null) {
-      controller = DefaultDropdownMenuController.of(context);
-    } else {
-      controller = widget.controller;
-    }
+    if (controller == null) {
+      if (widget.controller == null) {
+        controller = DefaultDropdownMenuController.of(context);
+      } else {
+        controller = widget.controller;
+      }
 
-    if (controller != null) {
-      controller.addListener(_onController);
+      if (controller != null) {
+        controller.addListener(_onController);
+      }
     }
     super.didChangeDependencies();
   }


### PR DESCRIPTION
原因: 跳转到其他页面的时候会重复调用 didChangeDependencies , 导致添加多个 listener , 回到页面之后点击时会重复触发点击事件, 开启 => 关闭